### PR TITLE
Fix os exit bug in MoveIt scripts

### DIFF
--- a/003_moveit_config/scripts/moveit_fk_demo.py
+++ b/003_moveit_config/scripts/moveit_fk_demo.py
@@ -5,6 +5,7 @@
 
 import rospy, sys
 import moveit_commander
+import os
 from moveit_msgs.msg import RobotTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
 
@@ -95,7 +96,7 @@ def MoveItFkDemo():
 
     # 关闭并退出moveit
     moveit_commander.roscpp_shutdown()
-    moveit_commander.os._exit(0)
+    os._exit(0)
 
 
 # 根据接收到的armcontrol_Info更新期望数据

--- a/003_moveit_config/scripts/moveit_fk_demo_2.py
+++ b/003_moveit_config/scripts/moveit_fk_demo_2.py
@@ -5,6 +5,7 @@
 
 import rospy, sys
 import moveit_commander
+import os
 from control_msgs.msg import GripperCommand
 
 class MoveItFkDemo:
@@ -28,7 +29,7 @@ class MoveItFkDemo:
         
         # 关闭并退出moveit
         moveit_commander.roscpp_shutdown()
-        moveit_commander.os._exit(0)
+        os._exit(0)
         
 if __name__ == "__main__":
     try:

--- a/003_moveit_config/scripts/moveit_fk_demo_work.py
+++ b/003_moveit_config/scripts/moveit_fk_demo_work.py
@@ -5,6 +5,7 @@
 
 import rospy, sys
 import moveit_commander
+import os
 from control_msgs.msg import GripperCommand
 import geometry_msgs.msg
 
@@ -113,7 +114,7 @@ class MoveItFkDemo:
         
         # 关闭并退出moveit
         moveit_commander.roscpp_shutdown()
-        moveit_commander.os._exit(0)
+        os._exit(0)
 
 if __name__ == "__main__":
     try:

--- a/003_moveit_config/scripts/moveit_ik_demo.py
+++ b/003_moveit_config/scripts/moveit_ik_demo.py
@@ -5,6 +5,7 @@
 
 import rospy, sys
 import moveit_commander
+import os
 from moveit_msgs.msg import RobotTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
 
@@ -156,7 +157,7 @@ def MoveItIkDemo():
 
     # 关闭并退出moveit
     moveit_commander.roscpp_shutdown()
-    moveit_commander.os._exit(0)
+    os._exit(0)
 
 
 # 根据接收到的armcontrol_Info更新期望数据

--- a/003_moveit_config/scripts/moveit_ik_demo_vision.py
+++ b/003_moveit_config/scripts/moveit_ik_demo_vision.py
@@ -10,6 +10,7 @@
 
 import rospy, sys
 import moveit_commander
+import os
 from moveit_msgs.msg import RobotTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
 
@@ -133,7 +134,7 @@ def MoveItIkDemo():
 
     # 关闭并退出moveit
     moveit_commander.roscpp_shutdown()
-    moveit_commander.os._exit(0)
+    os._exit(0)
 
 # 从/tag_detections刷新xy数据
 #arm_position_x = 0.2 + camera.x

--- a/003_moveit_config/scripts/mycode/positions_publisher.py
+++ b/003_moveit_config/scripts/mycode/positions_publisher.py
@@ -29,7 +29,7 @@ def number_callback(msg):
     data.arm_orientation_y = 0.5
     data.arm_orientation_z = 0.5
     data.arm_orientation_w = 0.5
-    print(data.arm_position_x,data.arm_position_x)
+    print(data.arm_position_x, data.arm_position_y)
     if nt % 5 == 0:
         pub.publish(data)
     nt += 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test_*.py


### PR DESCRIPTION
## Summary
- fix wrong exit calls by importing `os` and using `os._exit(0)`
- adjust print statement in `positions_publisher.py`
- configure pytest to ignore non-test files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522bf7af648329934fbf0b7eb6fe45