### PR TITLE
Add Python motor driver example package

### DIFF
--- a/motor_driver/CMakeLists.txt
+++ b/motor_driver/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(motor_driver)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+  armcontrol_demo_pkg
+)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS
+  scripts/motor_control_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/motor_driver/package.xml
+++ b/motor_driver/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>motor_driver</name>
+  <version>0.0.0</version>
+  <description>Simple Python motor control publisher</description>
+  <maintainer email="user@example.com">user</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>armcontrol_demo_pkg</build_depend>
+
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>armcontrol_demo_pkg</exec_depend>
+
+</package>

--- a/motor_driver/scripts/motor_control_node.py
+++ b/motor_driver/scripts/motor_control_node.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import rospy
+from armcontrol_demo_pkg.msg import hdrarm_msg
+
+
+def main():
+    rospy.init_node('motor_control_node')
+
+    pub = rospy.Publisher('/armcontrol_Info', hdrarm_msg, queue_size=10)
+
+    msg = hdrarm_msg()
+    msg.motor_state = 'enable'
+    msg.arm_mode = 'arm_control_demo'
+    msg.Emergency_Stop = False
+    msg.drag_teachin = 'false'
+    msg.drag_teachin_name = 'drag_teachin_1.txt'
+
+    msg.joint1_angle = 0.0
+    msg.joint2_angle = 0.0
+    msg.joint3_angle = 0.0
+    msg.joint4_angle = 0.0
+    msg.joint5_angle = 0.0
+    msg.joint6_angle = 0.0
+
+    msg.arm_position_x = 0.0
+    msg.arm_position_y = 0.0
+    msg.arm_position_z = 0.0
+    msg.arm_orientation_x = 0.0
+    msg.arm_orientation_y = 0.0
+    msg.arm_orientation_z = 0.0
+    msg.arm_orientation_w = 1.0
+
+    rate = rospy.Rate(10)
+    while not rospy.is_shutdown():
+        pub.publish(msg)
+        rate.sleep()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add new `motor_driver` ROS package
- implement Python node `motor_control_node.py` publishing motor commands

## Testing
- `catkin_make --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522bf7f36083299bc44d26bc6da66a